### PR TITLE
Suppress 'no server running on ...' message.

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -21,7 +21,7 @@ if not set -q TMUX
   set -l tmux_bin (config tmux-zen --get tmux-bin --default tmux)
   set -l session_name (config tmux-zen --get session-name --default local)
 
-  if eval "$tmux_bin has-session -t $session_name"
+  if eval "$tmux_bin has-session -t $session_name 2> /dev/null"
     exec env -- $tmux_bin new-session -t $session_name \; set destroy-unattached on \; new-window
   else
     exec env -- $tmux_bin new-session -s $session_name


### PR DESCRIPTION
When tmux-zen tests for an existing tmux session in order to either connect to it or create a new one, the error message 'no server running on /tmp/tmux-1000/default' pops up for a very short moment in case no session exists yet. Mostly, this message cannot be seen, because instantly afterwards a new session will be created. But sometimes when the system is under load, it is possible to see it. A simple fix is to append '2> /dev/null' to the 'tmux has-session' query.