### PR TITLE
Fix: Don't use tmux on dumb terminals

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -4,6 +4,11 @@ if begin; not isatty; or not status --is-interactive; or test -n "$INSIDE_EMACS"
   exit
 end
 
+# If we're running in a dumb terminal, do nothing
+if test $TERM = "dumb"
+  exit
+end
+
 # If we're running in a superuser shell, do nothing.
 if test $USER = root
   exit


### PR DESCRIPTION
The `INSIDE_EMACS` environment variable is not being set on my tramp sessions,
which is making tramp-mode to get scared by tmux's output and complain about
the terminal not supporting clear.

While I could dive into why the variable is not being set, since I'd prefer to just
include this early return as it might be fixing a few other cases where running inside
tmux might be unexpected.
Besides, this would get things working out of the box.