### PR TITLE
Prevent new screens on login

### DIFF
--- a/functions/zen.fish
+++ b/functions/zen.fish
@@ -20,7 +20,8 @@ function zen -d "Manages your tmux zen environment" -a command
     # Pass through commands to tmux.
     case tmux
       set -l tmux_bin (config tmux-zen --get tmux-bin --default tmux)
-      eval $tmux_bin "$argv"
+      set -l tmux_conf (config tmux-zen --get tmux-conf --default "$HOME/.tmux.conf")
+      eval $tmux_bin -f $tmux_conf "$argv"
 
     case '*'
       echo "Unknown command `$command'." >&2

--- a/functions/zen.help.fish
+++ b/functions/zen.help.fish
@@ -21,6 +21,7 @@ Commands
 
   $b"tmux"$n [$b"-2CluvV"$n] [$b"-c"$n $u"shell-command"$n] [$b"-f"$n $u"file"$n] [$b"-L"$n $u"socket-name"$n] [$b"-S"$n $u"socket-path"$n] [$u"command"$n [$u"flags"$n]]
     Runs the configured tmux application along with any other arguments. The
-    binary that is executed is determined by the `tmux-bin` config option.
+    binary that is executed is determined by the `tmux-bin` config option. The
+    config to use is determined by the `tmux-conf` config option.
 "
 end

--- a/init.fish
+++ b/init.fish
@@ -24,12 +24,13 @@ end
 # Connect to the TMUX session if it exists, or create it if it doesn't.
 if not set -q TMUX
   set -l tmux_bin (config tmux-zen --get tmux-bin --default tmux)
+  set -l tmux_conf (config tmux-zen --get tmux-conf --default "$HOME/.tmux.conf")
   set -l session_name (config tmux-zen --get session-name --default local)
 
   if eval "$tmux_bin has-session -t $session_name 2> /dev/null"
-    exec env -- $tmux_bin new-session -t $session_name \; set destroy-unattached on \; new-window
+    exec env -- $tmux_bin -f $tmux_conf new-session -t $session_name \; set destroy-unattached on \; new-window
   else
-    exec env -- $tmux_bin new-session -s $session_name
+    exec env -- $tmux_bin -f $tmux_conf new-session -s $session_name
   end
 end
 

--- a/init.fish
+++ b/init.fish
@@ -28,7 +28,7 @@ if not set -q TMUX
   set -l session_name (config tmux-zen --get session-name --default local)
 
   if eval "$tmux_bin has-session -t $session_name 2> /dev/null"
-    exec env -- $tmux_bin -f $tmux_conf new-session -t $session_name \; set destroy-unattached on \; new-window
+    exec env -- $tmux_bin -f $tmux_conf new-session -t $session_name \; set destroy-unattached on \;
   else
     exec env -- $tmux_bin -f $tmux_conf new-session -s $session_name
   end


### PR DESCRIPTION
For some reason, this plugin creates a new window each new connection. I'm not sure why this behaviour is needed, and this pull request removes it (in addition to bringing in the changes from #11 )