### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/functions/zen.fish
+++ b/functions/zen.fish
@@ -7,7 +7,7 @@ function zen -d "Manages your tmux zen environment" -a command
 
     case notify
       if not count $argv > /dev/null
-        cat ^/dev/null | read -l line
+        cat 2>/dev/null | read -l line
         set argv[1] "$line"
       end
 


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
