### PR TITLE
Use single command for attaching to session or starting a new one

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -26,11 +26,7 @@ if not set -q TMUX
   set -l tmux_bin (config tmux-zen --get tmux-bin --default tmux)
   set -l session_name (config tmux-zen --get session-name --default local)
 
-  if eval "$tmux_bin has-session -t $session_name 2> /dev/null"
-    exec env -- $tmux_bin new-session -t $session_name \; set destroy-unattached on \; new-window
-  else
-    exec env -- $tmux_bin new-session -s $session_name
-  end
+  exec env -- $tmux_bin new-session -A -s $session_name
 end
 
 # Initialize the session if we didn't already.


### PR DESCRIPTION
I'm getting my terminals to close with "tmux duplicate session" errors as tmux resurrect sometimes wins the race to create the session.

This avoids the race by using a single tmux call.